### PR TITLE
Add Google Form issue refinement workflow

### DIFF
--- a/.github/workflows/new-google-form-issue.yml
+++ b/.github/workflows/new-google-form-issue.yml
@@ -1,0 +1,40 @@
+name: New Google Form Issue
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  refine:
+    if: |
+      contains(github.event.issue.labels.*.name, 'googleForm') &&
+      !contains(github.event.issue.labels.*.name, 'refined')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Refine Google Form Issue
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are processing issue #${{ github.event.issue.number }} created from a Google Form submission.
+
+            Steps:
+            1. Read the current issue title and body using `gh issue view ${{ github.event.issue.number }}`
+            2. Translate the form content to English (the original may be in any language)
+            3. Create a concise, meaningful English title. Keep the "RF-X:" prefix from the original title if present
+            4. Update the issue body with this structure:
+               - English description of the reported issue at the top
+               - A horizontal rule (---)
+               - Original body text preserved unchanged below the rule
+            5. Apply the changes:
+               - `gh issue edit ${{ github.event.issue.number }} --title "<new title>" --body "<new body>"`
+               - `gh issue edit ${{ github.event.issue.number }} --add-label "refined"`


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that auto-processes issues created from Google Form submissions
- Uses Claude Code Action to translate the issue body to English and generate a meaningful title
- Preserves original form text below a horizontal rule separator
- Adds `refined` label after processing to prevent duplicate runs

## Test plan
- [x] Merge PR
- [x] Remove `googleForm` label from issue #3, then re-add it
- [ ] Verify the workflow triggers and updates the issue title, body, and adds `refined` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)