### PR TITLE
Fix: allow gh CLI tools in issue refinement workflow

### DIFF
--- a/.github/workflows/new-google-form-issue.yml
+++ b/.github/workflows/new-google-form-issue.yml
@@ -24,6 +24,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: |
+            Bash(gh issue view:*)
+            Bash(gh issue edit:*)
           prompt: |
             You are processing issue #${{ github.event.issue.number }} created from a Google Form submission.
 


### PR DESCRIPTION
## Summary
- Adds `allowed_tools` for `Bash(gh issue view:*)` and `Bash(gh issue edit:*)` to the Google Form issue workflow
- Fixes permission denials that prevented Claude Code from reading and updating issues

## Context
The previous run failed because all Bash tool calls were denied — Claude Code needs explicit `allowed_tools` to use `gh` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)