### PR TITLE
Fix: use claude_args for allowed tools in issue workflow

### DIFF
--- a/.github/workflows/new-google-form-issue.yml
+++ b/.github/workflows/new-google-form-issue.yml
@@ -24,7 +24,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash(gh issue view:*)" "Bash(gh issue edit:*)"'
+          claude_args: |
+            --allowedTools "Bash(gh issue view),Bash(gh issue edit)"
           prompt: |
             You are processing issue #${{ github.event.issue.number }} created from a Google Form submission.
 


### PR DESCRIPTION
## Summary
- Replaces invalid `allowed_tools` input with `claude_args` using the `--allowedTools` CLI flag
- Allows Claude Code to use `gh issue view` and `gh issue edit` during processing

## Context
Previous attempts failed because:
1. First run: no tool permissions — all `gh` calls denied
2. Second run: `allowed_tools` is not a valid action input

Now using the correct `claude_args` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)