### PR TITLE
Update workflow: feedbackForm label and NEW REQUEST title

### DIFF
--- a/.github/workflows/new-google-form-issue.yml
+++ b/.github/workflows/new-google-form-issue.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   refine:
     if: |
-      contains(github.event.issue.labels.*.name, 'googleForm') &&
+      contains(github.event.issue.labels.*.name, 'feedbackForm') &&
       !contains(github.event.issue.labels.*.name, 'refined')
     runs-on: ubuntu-latest
     permissions:
@@ -32,7 +32,7 @@ jobs:
             Steps:
             1. Read the current issue title and body using `gh issue view ${{ github.event.issue.number }}`
             2. Translate the form content to English (the original may be in any language)
-            3. Create a concise, meaningful English title. Keep the "RF-X:" prefix from the original title if present
+            3. Create a concise, meaningful English title (the original title is just "NEW REQUEST" placeholder, replace it entirely)
             4. Update the issue body with this structure:
                - English description of the reported issue at the top
                - A horizontal rule (---)


### PR DESCRIPTION
## Summary
- Change trigger label from `googleForm` to `feedbackForm`
- Update prompt to replace `NEW REQUEST` placeholder title entirely instead of keeping RF-X prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)