### PR TITLE
Replace Attributes tables with Properties lists

### DIFF
--- a/docs/domain/item.md
+++ b/docs/domain/item.md
@@ -2,19 +2,17 @@
 
 A clothing piece in the user's digital wardrobe. Item is the central entity of the system — most features and flows revolve around creating, viewing, and organizing items.
 
-## Attributes
+## Properties
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| Photo | Image | User-provided photo of the clothing piece. Background is removed automatically after upload. |
-| Type | String | Specific kind of clothing (e.g. t-shirt, jeans, sneakers). Detected by [AI Recognition](/features/ai-recognition). |
-| Category | [Category](/domain/category) | High-level grouping (e.g. tops, bottoms, shoes). Detected by AI or assigned manually. |
-| Color | Color | Dominant color of the garment. Detected automatically. |
-| Tags | [Tag](/domain/tag)[] | User-defined labels for organization. |
+- **Photo** — user-provided photo of the clothing piece. Background is removed automatically after upload.
+- **Type** — specific kind of clothing (e.g. t-shirt, jeans, sneakers). Detected by [AI Recognition](/features/ai-recognition).
+- **Category** — high-level grouping such as tops, bottoms, or shoes. See [Category](/domain/category). Detected by AI or assigned manually.
+- **Color** — dominant color of the garment. Detected automatically.
+- **Tags** — user-defined labels for organization. See [Tag](/domain/tag).
 
 > [!NOTE]
 > **Undefined — requires clarification:**
-> - Full list of Item attributes (name, brand, season, size, notes, etc.).
+> - Full list of Item properties (name, brand, season, size, notes, etc.).
 > - Whether Type is a free-form string or a fixed enum.
 > - How the processed (background-removed) image relates to the original photo — are both stored?
 > - Whether Item has a creation date, last-modified date, or other metadata.

--- a/docs/domain/outfit.md
+++ b/docs/domain/outfit.md
@@ -2,12 +2,10 @@
 
 A combination of [Items](/domain/item) arranged together to represent a look. Users create outfits by placing items on an interactive [canvas](/features/outfit-canvas).
 
-## Attributes
+## Properties
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| Canvas data | CanvasState | Positions, scales, and rotations of items on the canvas. Uses normalized coordinates for multi-screen support. |
-| Items | [Item](/domain/item)[] | The clothing pieces included in this outfit. |
+- **Canvas data** — positions, scales, and rotations of items on the canvas. Uses normalized coordinates for multi-screen support.
+- **Items** — the clothing pieces included in this outfit. See [Item](/domain/item).
 
 > [!NOTE]
 > **Undefined — requires clarification:**

--- a/docs/domain/tag.md
+++ b/docs/domain/tag.md
@@ -4,11 +4,9 @@ A user-defined label attached to [Items](/domain/item) for flexible organization
 
 Tags allow users to create their own groupings (e.g. "summer", "work", "favorites", "to donate").
 
-## Attributes
+## Properties
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| Name | String | The label text. |
+- **Name** — the label text displayed on the tag.
 
 > [!NOTE]
 > **Undefined — requires clarification:**

--- a/docs/domain/user.md
+++ b/docs/domain/user.md
@@ -2,11 +2,9 @@
 
 A person who uses the app to manage their wardrobe. User is the owner of all [Items](/domain/item), [Outfits](/domain/outfit), and other personal data in the system.
 
-## Attributes
+## Properties
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| Apple ID | External ID | Identifier from Apple sign-in. Used for authentication. |
+- **Apple ID** — identifier from Apple sign-in. Used for authentication.
 
 > [!NOTE]
 > **Undefined — requires clarification:**


### PR DESCRIPTION
## Summary

- Renamed `## Attributes` → `## Properties` in all domain entity docs
- Replaced programmer-style tables (with Type column like String, Image, CanvasState) with plain text lists
- Affected files: `item.md`, `outfit.md`, `tag.md`, `user.md`

## Test plan

- [x] Run `npx docsify-cli serve docs` and check domain pages render correctly
- [x] Verify cross-links within property descriptions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)