### PR TITLE
Add system constraints documentation

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,11 @@
 - [ROBE Documentation](/)
 
+- **Constraints**
+  - [Platform](constraints/platform.md)
+  - [Localization](constraints/localization.md)
+  - [Data & Sync](constraints/data-sync.md)
+  - [Open Questions](constraints/open-questions.md)
+
 - **Domain**
   - [Item](domain/item.md)
   - [Outfit](domain/outfit.md)

--- a/docs/constraints/data-sync.md
+++ b/docs/constraints/data-sync.md
@@ -1,0 +1,24 @@
+# Data & Sync
+
+The application follows a **local-first** approach: the device is the primary data source, and the app works offline by default.
+
+## Offline Behavior
+
+- All core functionality — browsing the wardrobe, viewing items, creating and editing outfits — is available without a network connection.
+- Features that rely on server-side processing (e.g. [AI Recognition](/features/ai-recognition)) require a network connection. When the network is unavailable, these features are either deferred or disabled.
+
+## Cloud Sync
+
+User data is synchronized to a backend to support:
+
+- **Multi-device access** — signing in on a new device restores the full wardrobe.
+- **Data recovery** — reinstalling the app or switching devices does not result in data loss.
+
+The backend serves as a secondary copy. The local device is the source of truth during normal operation.
+
+> [!NOTE]
+> **Undefined — requires clarification:**
+> - Conflict resolution strategy when the same data is modified on multiple devices.
+> - What exactly is synced (items, outfits, tags, preferences, photos)?
+> - Whether sync happens in real-time, periodically, or on specific triggers.
+> - Behavior when sync fails or is interrupted.

--- a/docs/constraints/localization.md
+++ b/docs/constraints/localization.md
@@ -1,0 +1,12 @@
+# Localization
+
+The application supports multiple languages.
+
+## Supported Languages
+
+| Language | Role |
+|----------|------|
+| English  | Primary. Used as the default language and the base for all content. |
+| Russian  | Secondary. Full translation of the interface. |
+
+The user's device language setting determines which language is displayed. If the device language is not supported, English is used as a fallback.

--- a/docs/constraints/open-questions.md
+++ b/docs/constraints/open-questions.md
@@ -1,0 +1,66 @@
+# Open Questions
+
+Topics that need to be defined as the product evolves. Each section describes what needs to be decided and why it matters.
+
+---
+
+## Authentication
+
+How users sign in and identify themselves. Affects onboarding complexity, account recovery, and data sync.
+
+- Sign-in methods: Apple Sign In, email/password, social login, anonymous usage?
+- Is sign-in required to use the app, or only for sync features?
+- Account deletion flow and data retention after deletion.
+
+See also: [Onboarding](/flows/onboarding).
+
+---
+
+## Storage & Limits
+
+Whether the system imposes limits on user data. Affects product positioning and infrastructure costs.
+
+- Maximum number of items, outfits, or tags per user.
+- Photo storage limits (size, resolution, count).
+- Whether limits differ by plan (if monetization introduces tiers).
+
+---
+
+## Privacy & Data
+
+How user data — especially photos — is handled. Affects trust, compliance, and feature design.
+
+- Where photos are stored (device only, cloud, or both).
+- What data is sent to external services (e.g. images sent for AI recognition).
+- Data retention policy: how long is data kept after account deletion?
+- Whether any data is shared with third parties.
+
+---
+
+## Monetization
+
+The business model for the product. Affects feature scoping and which capabilities are gated.
+
+- Free, freemium, subscription, or one-time purchase?
+- If freemium: which features are free and which are paid?
+- Trial period or usage limits for premium features.
+
+---
+
+## Accessibility
+
+Support for users with disabilities. Affects UI design and testing requirements.
+
+- VoiceOver support for screen reader users.
+- Dynamic Type support for custom font sizes.
+- Contrast and color considerations for color-related features (e.g. color detection, filtering by color).
+
+---
+
+## Performance
+
+Expected responsiveness and loading behavior. Affects architecture and perceived quality.
+
+- Target launch time and time-to-interactive.
+- Image loading and rendering performance expectations.
+- Scroll performance in large wardrobes (hundreds of items).

--- a/docs/constraints/platform.md
+++ b/docs/constraints/platform.md
@@ -1,0 +1,11 @@
+# Platform
+
+The application is available as a native iOS mobile app.
+
+## Supported Devices
+
+- **iPhone only** — the app is designed for iPhone form factor. iPad and other Apple devices are not supported.
+- **iOS only** — there is no Android, web, or desktop version.
+- **iOS 26+** — minimum supported version. This covers all iPhone models with an A13 Bionic chip or newer (iPhone 11 and later).
+- **Portrait orientation only** — the app does not support landscape mode.
+- **All supported iPhone models** — no model-specific restrictions beyond the iOS 26 requirement.


### PR DESCRIPTION
## Summary
- Add new `docs/constraints/` section for non-functional requirements
- **Platform** — iOS 26+, iPhone only, portrait orientation
- **Localization** — English (primary) + Russian
- **Data & Sync** — local-first architecture, cloud sync for multi-device and recovery
- **Open Questions** — authentication, storage limits, privacy, monetization, accessibility, performance

## Test plan
- [x] Run `npx docsify-cli serve docs` and verify sidebar shows Constraints section
- [x] Verify all 4 new pages render correctly
- [x] Verify existing pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)