### PR TITLE
Add /voice-input skill and NOTE block convention

### DIFF
--- a/.claude/skills/voice-input/SKILL.md
+++ b/.claude/skills/voice-input/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: voice-input
+description: "Process voice-transcribed product notes and update documentation"
+argument-hint: "<voice transcription>"
+disable-model-invocation: true
+---
+
+You are a documentation maintainer for this product. The user will provide informal voice-transcribed text — possibly messy or unstructured. Transcription may contain errors and misspellings; focus on the meaning, not the literal words. Your job is to turn it into documentation updates.
+
+## Current documentation files
+
+!`find docs -name "*.md" | sort`
+
+## Workflow
+
+### 1. Understand the input
+
+Parse the voice transcription. Extract concrete facts, decisions, clarifications, and new concepts.
+
+If the input is vague or you cannot extract actionable information, ask the user to clarify before proceeding.
+
+### 2. Read relevant docs
+
+Based on what you extracted, read the existing documentation files that may be affected. Understand what is already documented.
+
+### 3. Group into topics
+
+If the input touches multiple unrelated subjects, identify each distinct topic. Each topic will become a separate branch.
+
+### 4. Check for contradictions
+
+Compare every extracted fact against existing documentation. If something contradicts what is already written:
+
+- Show the user what the docs currently say vs. what the new input implies
+- Ask for explicit confirmation before overwriting
+- Do NOT silently change existing documented decisions
+
+### 5. Ask clarifying questions
+
+Be proactive. If something is:
+
+- **Ambiguous** — could be interpreted multiple ways
+- **Incomplete** — implies more than it states
+- **Surprising** — seems unusual for the product
+
+Ask before writing. It is better to ask one extra question than to write wrong documentation.
+
+### 6. Resolve `> [!NOTE]` blocks
+
+Search for `> [!NOTE]` blocks across all docs. If the input provides clarity on any of them, update or remove those blocks.
+
+### 7. Split into branches
+
+If there are multiple unrelated topics:
+
+- Create a `docs/<topic>` branch for each
+- Apply the relevant changes on each branch
+- Tell the user which branches were created
+
+If there is only one topic, work on a single `docs/<topic>` branch.
+
+### 8. Apply changes
+
+Edit existing files or create new ones. Follow all rules from CLAUDE.md — they are already in your context.
+
+After applying changes, run through the Pre-Commit Checklist from CLAUDE.md.
+
+## Input
+
+$ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Focus on: trigger, steps, decision points, success/failure outcomes.
 - Use absolute paths from docs root without `.md` extension for cross-links: `[Item](/domain/item)`, `[AI Recognition](/features/ai-recognition)`.
 - Keep `_sidebar.md` updated — it defines site navigation.
 - Write for someone who has never seen the app. Be specific enough that a developer could implement from the description.
-- When something is unclear or undefined, note it explicitly rather than guessing.
+- **Mark unknowns explicitly.** When something is unclear or undefined, add a `> [!NOTE]` block rather than guessing. These blocks are knowledge gap markers across the documentation. When new information resolves a `> [!NOTE]` block, update or remove it.
 
 ## Branch Naming
 


### PR DESCRIPTION
## Summary
- Adds a project-specific `/voice-input` skill that processes informal voice-transcribed product notes into structured documentation updates
- Formalizes the `> [!NOTE]` block convention in CLAUDE.md as the standard way to mark knowledge gaps across docs
- The skill handles contradiction detection, clarifying questions, NOTE block resolution, and automatic branch splitting per topic

## Test plan
- [x] Invoke `/voice-input` with a test phrase and verify it reads existing docs and responds appropriately
- [x] Invoke `/voice-input` with a real product decision and verify it creates a branch and updates the correct doc files

🤖 Generated with [Claude Code](https://claude.com/claude-code)