### PR TITLE
Add version-controlled Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git push:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git fetch:*)",
+      "Bash(git mv:*)",
+      "Bash(git rebase:*)",
+      "Bash(git pull:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh pr:*)",
+      "Bash(npx docsify-cli serve:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with shared permission rules for the project, replacing the local-only `settings.local.json`

## Test plan

- [x] Verify Claude Code picks up permissions from the shared settings file

🤖 Generated with [Claude Code](https://claude.com/claude-code)