### PR TITLE
Use full check results and 10 min timeout for PR merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Before committing, verify that all related parts of the documentation are consis
 
 ## Pull Request Merge
 
-When asked to merge a PR, wait for all checks to finish (`gh pr checks <number> --watch --fail-fast`), then:
+When asked to merge a PR, wait for all checks to finish (`gh pr checks <number> --watch`, timeout 10 min), then:
 
 - **All checks pass, no review comments** — merge with `--squash`.
 - **Review comments exist** — read them, summarize for the user, and ask whether to apply changes or merge as-is.


### PR DESCRIPTION
## Summary

- Remove `--fail-fast` from PR checks watch command to see all check results before deciding.
- Add 10 min timeout guidance since CI actions may run up to that long.

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)