### PR TITLE
Add summary paragraph to documentation context section

### DIFF
--- a/.github/workflows/new-form-request.yml
+++ b/.github/workflows/new-form-request.yml
@@ -41,7 +41,8 @@ jobs:
                - Read `docs/_sidebar.md` to get the full documentation index
                - Identify which features, entities, or flows are mentioned or implied by the request
                - Read the relevant doc files to understand what is already documented
-               - Compose a brief "Documentation Context" section with links to relevant docs
+               - Compose a "Documentation Context" section that starts with a brief summary paragraph (1-3 sentences) explaining how this request relates to what is already documented — what exists, what would need to change, what gaps there are
+               - Below the summary, list links to relevant docs
                - Use this link format: ${{ github.server_url }}/${{ github.repository }}/blob/main/docs/<path>
                - Each link should have a one-line note on why it is relevant
                - Omit this section entirely if no docs are relevant


### PR DESCRIPTION
## Summary

- Update the form request refinement prompt to produce a brief 1-3 sentence summary paragraph at the top of the Documentation Context section
- The summary explains how the request relates to existing docs — what's already covered, what would need to change, what gaps exist
- Doc links remain listed below the summary as before

## Test plan

- [ ] Create a test issue with `feedbackForm` label
- [ ] Verify the Documentation Context section now starts with a human-readable summary before the links

🤖 Generated with [Claude Code](https://claude.com/claude-code)