### PR TITLE
Fix missed tag references in constraint files

### DIFF
--- a/docs/constraints/data-sync.md
+++ b/docs/constraints/data-sync.md
@@ -19,6 +19,6 @@ The backend serves as a secondary copy. The local device is the source of truth 
 > [!NOTE]
 > **Undefined — requires clarification:**
 > - Conflict resolution strategy when the same data is modified on multiple devices.
-> - What exactly is synced (items, outfits, tags, preferences, photos)?
+> - What exactly is synced (items, outfits, collections, preferences, photos)?
 > - Whether sync happens in real-time, periodically, or on specific triggers.
 > - Behavior when sync fails or is interrupted.

--- a/docs/constraints/open-questions.md
+++ b/docs/constraints/open-questions.md
@@ -20,7 +20,7 @@ See also: [Onboarding](../flows/onboarding.md).
 
 Whether the system imposes limits on user data. Affects product positioning and infrastructure costs.
 
-- Maximum number of items, outfits, or tags per user.
+- Maximum number of items, outfits, or collections per user.
 - Photo storage limits (size, resolution, count).
 - Whether limits differ by plan (if monetization introduces tiers).
 


### PR DESCRIPTION
## Summary
- Fix 2 remaining "tags" → "collections" references missed in #62
- `docs/constraints/data-sync.md` — sync data list
- `docs/constraints/open-questions.md` — storage limits section

Caught by claude[bot] review on #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)