### PR TITLE
Update Item properties, rename AI Recognition to AI Classification, add Edit Item flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Focus on: attributes, relationships, constraints, edge cases (what happens when 
 
 Describes what the product can do. Each feature is a distinct capability that delivers value to the user.
 
-Examples: item recognition, wardrobe filtering, outfit collage.
+Examples: AI classification, wardrobe filtering, outfit collage.
 
 Focus on: purpose, behavior, UI elements, error handling.
 
@@ -63,7 +63,7 @@ Focus on: trigger, steps, decision points, success/failure outcomes.
 
 - **Single source of truth.** Define each concept in exactly one place. Other files that mention it should link to the source rather than repeat the description. For example, a flow step should say `[Collections](../domain/collection.md)` instead of re-explaining what a collection is. This keeps updates localized to one file.
 - One file = one concept. Split when a file grows beyond its scope.
-- Use relative paths with `.md` extension for cross-links: `[Category](./category.md)`, `[AI Recognition](../features/ai-recognition.md)`. Paths are relative to the file containing the link.
+- Use relative paths with `.md` extension for cross-links: `[Category](./category.md)`, `[AI Classification](../features/ai-classification.md)`. Paths are relative to the file containing the link.
 - Keep `_sidebar.md` updated — it defines site navigation.
 - Write for someone who has never seen the app. Be specific enough that a developer could implement from the description.
 - **Mark unknowns explicitly.** When something is unclear or undefined, add a `> [!NOTE]` block rather than guessing. These blocks are knowledge gap markers across the documentation. When new information resolves a `> [!NOTE]` block, update or remove it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,6 @@ Both problems are wardrobe management at their core. The app takes an AI-first a
 
 ## How It Works
 
-- **Wardrobe management** — add, edit, and organize clothing items. [AI recognition](./features/ai-recognition.md) detects clothing type, category, and attributes from a photo, so adding items is fast.
+- **Wardrobe management** — add, edit, and organize clothing items. [AI Classification](./features/ai-classification.md) detects clothing type and attributes from a photo, so adding items is fast.
 - **Outfit creation** — combine items into outfits using an interactive [collage](./features/outfit-collage.md) and capture a photo of the look.
 - **Filtering & search** — find items by category, type, color, and collections to quickly browse what you have.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,7 +14,7 @@
   - [User](/domain/user.md)
 
 - **Features**
-  - [AI Recognition](/features/ai-recognition.md)
+  - [AI Classification](/features/ai-classification.md)
   - [Background Removal](/features/background-removal.md)
   - [Wardrobe Filtering](/features/wardrobe-filtering.md)
   - [Outfit Collage](/features/outfit-collage.md)
@@ -22,5 +22,6 @@
 
 - **Flows**
   - [Add Item](/flows/add-item.md)
+  - [Edit Item](/flows/edit-item.md)
   - [Create Outfit](/flows/create-outfit.md)
   - [Onboarding](/flows/onboarding.md)

--- a/docs/constraints/data-sync.md
+++ b/docs/constraints/data-sync.md
@@ -5,7 +5,7 @@ The application follows a **local-first** approach: the device is the primary da
 ## Offline Behavior
 
 - All core functionality — browsing the wardrobe, viewing items, creating and editing outfits — is available without a network connection.
-- Features that rely on server-side processing (e.g. [AI Recognition](../features/ai-recognition.md)) require a network connection. When the network is unavailable, these features are either deferred or disabled.
+- Features that rely on server-side processing (e.g. [AI Classification](../features/ai-classification.md)) require a network connection. When the network is unavailable, these features are either deferred or disabled.
 
 ## Cloud Sync
 

--- a/docs/constraints/open-questions.md
+++ b/docs/constraints/open-questions.md
@@ -31,7 +31,7 @@ Whether the system imposes limits on user data. Affects product positioning and 
 How user data — especially photos — is handled. Affects trust, compliance, and feature design.
 
 - Where photos are stored (device only, cloud, or both).
-- What data is sent to external services (e.g. images sent for AI recognition).
+- What data is sent to external services (e.g. images sent for AI classification).
 - Data retention policy: how long is data kept after account deletion?
 - Whether any data is shared with third parties.
 

--- a/docs/domain/category.md
+++ b/docs/domain/category.md
@@ -1,28 +1,30 @@
 # Category
 
-A high-level classification of clothing items. Categories group [Items](./item.md) into broad types (e.g. tops, bottoms, shoes, accessories).
+A high-level classification of wardrobe items. Categories group [Items](./item.md) into broad types (e.g. tops, bottoms, shoes, accessories).
 
 ## Structure
 
-Categories form a hierarchy that helps users navigate their wardrobe.
+Categories form a two-level hierarchy: each Category contains one or more Types. For example, the Category "Tops" might contain Types like "T-shirt", "Blouse", and "Sweater".
+
+- Categories and Types are predefined (system-level) and not user-customizable.
+- An [Item](./item.md) is assigned a Type, and its Category is derived from that Type. Items do not have a direct Category property.
+- [AI Classification](../features/ai-classification.md) detects the Type from a photo; Category follows automatically.
 
 > [!NOTE]
 > **Undefined — requires clarification:**
-> - Full list of top-level categories.
-> - Whether categories are nested (e.g. Tops > T-shirts > V-neck) or flat.
-> - Whether categories are predefined (system-level) or user-customizable.
-> - Relationship between Category and Item Type — is Type a subcategory, or a separate dimension?
+> - Full list of categories and their types.
 
 ## Relationships
 
-- A Category contains zero or more [Items](./item.md).
+- A Category contains one or more Types.
+- A Type belongs to exactly one Category.
+- An [Item](./item.md) has a Type, which determines its Category.
 - Categories are used as a filter dimension in [Wardrobe Filtering](../features/wardrobe-filtering.md).
-- Categories are auto-detected by [AI Recognition](../features/ai-recognition.md).
 
 ## Business Rules
 
+- Categories and Types are predefined by the system. Users cannot create, rename, or remove them.
+
 > [!NOTE]
 > **Undefined — requires clarification:**
-> - Can a user create custom categories?
-> - Can an Item belong to multiple categories?
-> - What happens if AI assigns a category that doesn't exist in the hierarchy?
+> - What happens if AI assigns a type that doesn't exist in the hierarchy?

--- a/docs/domain/collection.md
+++ b/docs/domain/collection.md
@@ -23,7 +23,7 @@ Collections let users define their own cross-cutting labels (e.g. "sporty", "eve
 
 ## Business Rules
 
-- Collections are created by the user. During item classification, [AI Recognition](../features/ai-recognition.md) can suggest assigning existing collections to a new item, but it does not create new collections.
+- Collections are created by the user. During item classification, [AI Classification](../features/ai-classification.md) can suggest assigning existing collections to a new item, but it does not create new collections.
 - An Item or Outfit can belong to zero or more Collections.
 
 > [!NOTE]

--- a/docs/domain/item.md
+++ b/docs/domain/item.md
@@ -1,22 +1,22 @@
 # Item
 
-A clothing piece in the user's digital wardrobe. Item is the central entity of the system — most features and flows revolve around creating, viewing, and organizing items.
+A piece in the user's digital wardrobe. Item is the central entity of the system — most features and flows revolve around creating, viewing, and organizing items.
 
 ## Properties
 
-- **Photo** — user-provided photo of the clothing piece. Background is removed by [Background Removal](../features/background-removal.md).
-- **Type** — specific kind of clothing (e.g. t-shirt, jeans, dress).
-- **Category** — high-level grouping. See [Category](./category.md).
-- **Color** — dominant color of the garment.
-- **Brand** — brand of the garment.
+- **Photo** — user-provided photo of the piece. Background is removed by [Background Removal](../features/background-removal.md).
+- **Name** — auto-generated from properties following the pattern "{color} {type} {brand}" (e.g. "Multicolor Skirt Chanel"). Updates automatically when properties change.
+- **Type** — specific kind of clothing or accessory (e.g. t-shirt, jeans, dress). Type comes from a predefined category-type hierarchy. See [Category](./category.md).
+- **Color** — dominant color of the piece. Selected from a predefined fixed set of colors.
+- **Brand** — brand of the piece. Selected from a predefined list; users can also add custom brands.
+- **Hidden** — when enabled, the item does not appear in the wardrobe or other views.
+- **Favorite** — marks the item as a favorite.
 - **Collections** — user-defined groupings for organization. See [Collection](./collection.md).
 
-All attributes are auto-detected or suggested by [AI Recognition](../features/ai-recognition.md) on creation and can be edited by the user.
+All attributes except Hidden and Favorite are auto-detected or suggested by [AI Classification](../features/ai-classification.md) on creation and can be edited by the user.
 
 > [!NOTE]
 > **Undefined — requires clarification:**
-> - Full list of remaining Item properties (name, season, size, notes, etc.).
-> - Whether Type is a free-form string or a fixed enum.
 > - How the processed (background-removed) image relates to the original photo — are both stored?
 > - Whether Item has a creation date, last-modified date, or other metadata.
 > - What happens when an Item is deleted but it belongs to one or more [Outfits](./outfit.md).
@@ -27,7 +27,7 @@ When a new item is added via the [Add Item](../flows/add-item.md) flow, it goes 
 
 1. **Processing** — [Background Removal](../features/background-removal.md) is running.
 2. **Uploading** — the processed photo is being uploaded.
-3. **Classifying** — [AI Recognition](../features/ai-recognition.md) is detecting attributes.
+3. **Classifying** — [AI Classification](../features/ai-classification.md) is detecting attributes.
 4. **Classified** — all processing is done; the item is fully ready for viewing and editing.
 
 The user can interact with other items and navigate the app while processing runs in the background.
@@ -35,7 +35,7 @@ The user can interact with other items and navigate the app while processing run
 ## Relationships
 
 - An Item belongs to one [User](./user.md).
-- An Item belongs to one [Category](./category.md).
+- An Item has one Type, and that Type belongs to a [Category](./category.md). Category is derived from Type, not stored directly on the Item.
 - An Item can have zero or more [Collections](./collection.md).
 - An Item can appear in zero or more [Outfits](./outfit.md).
 
@@ -45,6 +45,5 @@ The user can interact with other items and navigate the app while processing run
 
 > [!NOTE]
 > **Undefined — requires clarification:**
-> - Can an Item exist without a Category?
 > - Is there a limit on how many Collections an Item can have?
 > - Can an Item appear multiple times in the same Outfit?

--- a/docs/features/ai-classification.md
+++ b/docs/features/ai-classification.md
@@ -1,4 +1,4 @@
-# AI Recognition
+# AI Classification
 
 Automatically detects clothing attributes from a photo. Requires a background-removed image as input (see [Background Removal](./background-removal.md)).
 
@@ -10,12 +10,11 @@ Reduce manual effort when adding items. Instead of filling in every field by han
 
 ### Clothing Classification
 
-- Detects **type** of garment (e.g. t-shirt, jeans, dress).
-- Detects **category** (e.g. tops, bottoms, footwear).
+- Detects **type** of garment (e.g. t-shirt, jeans, dress). [Category](../domain/category.md) is derived from the detected type.
 
 ### Color Detection
 
-- Identifies the dominant color of the garment.
+- Identifies the dominant color of the garment from the predefined color set.
 
 ### Brand Detection
 
@@ -28,11 +27,11 @@ Reduce manual effort when adding items. Instead of filling in every field by han
 
 ## User Override
 
-All AI-detected attributes (type, category, color, brand, collections) can be reviewed and corrected by the user after classification completes.
+All AI-detected attributes (type, color, brand, collections) can be reviewed and corrected by the user after classification completes.
 
 > [!NOTE]
 > **Undefined — requires clarification:**
-> - What attributes beyond type, category, color, and brand does the AI detect (material, pattern, season, style)?
+> - What attributes beyond type, color, and brand does the AI detect (material, pattern, season, style)?
 > - What happens when AI classification fails or returns low confidence?
 
 ## Error Handling

--- a/docs/features/background-removal.md
+++ b/docs/features/background-removal.md
@@ -9,7 +9,7 @@ Isolate the clothing piece from its surroundings so it can be displayed consiste
 ## Behavior
 
 - Takes the original user photo as input and outputs a transparent cutout containing only the clothing piece.
-- Executes as the first step of the [Add Item](../flows/add-item.md) processing pipeline, before [AI Recognition](./ai-recognition.md).
+- Executes as the first step of the [Add Item](../flows/add-item.md) processing pipeline, before [AI Classification](./ai-classification.md).
 
 > [!NOTE]
 > **Undefined — requires clarification:**

--- a/docs/features/wardrobe-filtering.md
+++ b/docs/features/wardrobe-filtering.md
@@ -10,9 +10,9 @@ The wardrobe serves as a visual browser of everything the user owns. Its primary
 
 | Dimension | Source |
 |-----------|--------|
-| [Category](../domain/category.md) | AI-detected or manually assigned |
+| [Category](../domain/category.md) | Derived from Type |
 | Type | AI-detected or manually assigned |
-| Color | AI-detected |
+| Color | AI-detected or manually assigned; from a predefined color set |
 | [Collections](../domain/collection.md) | User-assigned |
 
 > [!NOTE]

--- a/docs/flows/add-item.md
+++ b/docs/flows/add-item.md
@@ -21,7 +21,7 @@ After confirmation, each item appears in the wardrobe right away with a visible 
 
 1. **Background removal** — [Background Removal](../features/background-removal.md) strips the background and produces a transparent cutout image.
 2. **Upload** — the processed photo is uploaded.
-3. **AI classification** — [AI Recognition](../features/ai-recognition.md) detects type, category, color, and brand, and suggests [Collections](../domain/collection.md).
+3. **AI classification** — [AI Classification](../features/ai-classification.md) detects type, color, and brand, and suggests [Collections](../domain/collection.md). [Category](../domain/category.md) is derived from the detected type.
 
 When multiple photos are selected from the gallery, all items are processed in parallel.
 

--- a/docs/flows/edit-item.md
+++ b/docs/flows/edit-item.md
@@ -1,0 +1,40 @@
+# Edit Item
+
+The flow of editing an existing [Item](../domain/item.md) in the user's wardrobe.
+
+## Trigger
+
+User taps an item in the wardrobe to open the item editing screen.
+
+## Editable Properties
+
+All [Item](../domain/item.md) properties can be modified:
+
+- **Type** — select from the predefined category-type hierarchy. Changing the type also changes the derived [Category](../domain/category.md).
+- **Color** — select from the predefined color set.
+- **Brand** — select from the predefined brand list or add a custom brand.
+- **Hidden** — toggle whether the item appears in the wardrobe.
+- **Favorite** — toggle favorite status.
+- **Collections** — add or remove [Collections](../domain/collection.md).
+
+The item **Name** auto-updates when type, color, or brand changes.
+
+## Photo Replacement
+
+The user can replace the item's photo. When a new photo is provided:
+
+1. [Background Removal](../features/background-removal.md) runs on the new photo.
+2. [AI Classification](../features/ai-classification.md) does **not** run — the user is editing a known item, so existing attributes are preserved.
+
+The user can manually adjust attributes after replacing the photo if needed.
+
+## Result
+
+Changes are saved and reflected immediately in the wardrobe and any [Outfits](../domain/outfit.md) that include the item.
+
+## Error Scenarios
+
+| Scenario | Expected Behavior |
+|----------|------------------|
+| Background removal fails on new photo | *Undefined* |
+| Network unavailable during photo upload | *Undefined* |


### PR DESCRIPTION
## Summary

- **Item entity**: added Name (auto-generated), Hidden, Favorite properties; clarified Color as predefined fixed set and Brand as predefined + user-extensible; removed Category as a direct property (now derived from Type)
- **Category-Type hierarchy**: documented that Categories contain Types, both predefined; Item stores Type, Category is derived
- **AI Recognition → AI Classification**: renamed feature across all docs (file, links, text references)
- **Edit Item flow**: new flow documenting item editing screen — all properties editable, photo replacement runs Background Removal but skips AI Classification

## Test plan

- [ ] Run `./scripts/check-links.py` — all links valid
- [ ] Verify `_sidebar.md` includes new Edit Item entry and renamed AI Classification
- [ ] Confirm no stale references to `ai-recognition` remain
- [ ] Preview with `npx docsify-cli serve docs` and check navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)