### PR TITLE
Clarify User entity: properties, auth, subscription, and deletion

### DIFF
--- a/docs/constraints/current-limitations.md
+++ b/docs/constraints/current-limitations.md
@@ -27,3 +27,15 @@ As limitations are resolved, remove them from this list.
 ## AI Collection Suggestion Not Yet Implemented
 
 [AI Classification](../features/ai-classification.md) lists collection suggestion as a capability, and [Collection](../domain/collection.md) describes AI suggesting existing collections during item classification. This feature is not yet implemented — collections are currently assigned manually by the user only.
+
+---
+
+## Subscription Not Yet Implemented
+
+[User](../domain/user.md) describes a subscription model that gates certain features and limits the number of items for free users. Currently, all features are available to all users with no paywall or item limits.
+
+---
+
+## Account Deletion Does Not Clean Up Cloud Data
+
+[User](../domain/user.md) states that all associated data is removed when an account is deleted. Currently, cloud-stored files (item images and other uploads) are not cleaned up during deletion and remain as orphans.

--- a/docs/constraints/open-questions.md
+++ b/docs/constraints/open-questions.md
@@ -8,9 +8,9 @@ Topics that need to be defined as the product evolves. Each section describes wh
 
 How users sign in and identify themselves. Affects onboarding complexity, account recovery, and data sync.
 
-- Sign-in methods: Apple Sign In, email/password, social login, anonymous usage?
-- Is sign-in required to use the app, or only for sync features?
-- Account deletion flow and data retention after deletion.
+Apple Sign In is the only authentication method, and it is required — there is no guest or anonymous usage. Account deletion is immediate with no data retention. See [User](../domain/user.md) for details.
+
+- What happens if a user loses access to their Apple ID — is there an account recovery path?
 
 See also: [Onboarding](../flows/onboarding.md).
 
@@ -20,9 +20,11 @@ See also: [Onboarding](../flows/onboarding.md).
 
 Whether the system imposes limits on user data. Affects product positioning and infrastructure costs.
 
-- Maximum number of items, outfits, or collections per user.
+Item count is limited for free users and unlimited (or higher) for subscribers. See [User](../domain/user.md).
+
+- What is the specific item limit for free users?
+- Are there limits on outfits or collections?
 - Photo storage limits (size, resolution, count).
-- Whether limits differ by plan (if monetization introduces tiers).
 
 ---
 
@@ -32,18 +34,17 @@ How user data — especially photos — is handled. Affects trust, compliance, a
 
 - Where photos are stored (device only, cloud, or both).
 - What data is sent to external services (e.g. images sent for AI classification).
-- Data retention policy: how long is data kept after account deletion?
 - Whether any data is shared with third parties.
 
 ---
 
 ## Monetization
 
-The business model for the product. Affects feature scoping and which capabilities are gated.
+The business model is freemium with a subscription that unlocks full functionality. See [User](../domain/user.md) for the subscription concept.
 
-- Free, freemium, subscription, or one-time purchase?
-- If freemium: which features are free and which are paid?
-- Trial period or usage limits for premium features.
+- Which specific features are gated behind the paywall?
+- Is there a trial period for the subscription?
+- What is the pricing model (monthly, yearly, both)?
 
 ---
 

--- a/docs/domain/user.md
+++ b/docs/domain/user.md
@@ -4,14 +4,13 @@ A person who uses the app to manage their wardrobe. User is the owner of all [It
 
 ## Properties
 
-- **Apple ID** — identifier from Apple sign-in. Used for authentication.
+- **Apple ID** — identifier from Apple sign-in. Used solely for authentication. No personal information (name, avatar, email) is retrieved or stored from the Apple ID.
+- **Subscription** — determines the user's access level. A subscription unlocks full app functionality: certain features are gated behind a paywall, and the number of [Items](./item.md) a user can create is limited for free users. See [Current Limitations](../constraints/current-limitations.md) for implementation status.
 
 > [!NOTE]
-> **Undefined — requires clarification:**
-> - Does the user have a display name, avatar, or email stored in the app?
-> - Are there any user-level settings or preferences (e.g. default sorting, theme)?
-> - Is there any subscription or plan associated with the user?
-> - What metadata is stored (registration date, last login)?
+> Subscription specifics are not yet defined: which features are gated, what the item limit is, and whether there is a trial period.
+
+The app stores no user metadata — no registration date, last login, display name, or preferences. The only stored association is the link between the Apple ID and the user's data.
 
 ## Relationships
 
@@ -20,11 +19,6 @@ A person who uses the app to manage their wardrobe. User is the owner of all [It
 
 ## Business Rules
 
-- A User must be authenticated via Apple ID to use the app.
-- When a User deletes their account, all associated data is removed.
-
-> [!NOTE]
-> **Undefined — requires clarification:**
-> - Is account deletion immediate or is there a grace period?
-> - What exactly is deleted — only app data, or is the Apple ID link also revoked?
-> - Can a user re-register with the same Apple ID after deletion?
+- A User must be authenticated via Apple ID to use the app. There is no guest or anonymous usage.
+- When a User deletes their account, all associated data is removed — items, outfits, collections, and the user record. Deletion is immediate after the user confirms the action in [Profile](../features/profile.md). See [Current Limitations](../constraints/current-limitations.md) for known gaps in the deletion process.
+- After deletion, the user can re-register with the same Apple ID. This creates a new, empty account with no connection to the previous one.


### PR DESCRIPTION
## Summary
- **user.md**: Resolve both NOTE blocks — document that no personal data is stored, add subscription as a planned property, clarify account deletion is immediate with re-registration support
- **current-limitations.md**: Add entries for subscription (not yet implemented) and account deletion cloud data cleanup (not yet implemented)
- **open-questions.md**: Update Authentication (resolved), Monetization (freemium chosen), Storage & Limits (item limits tied to subscription), Privacy & Data (remove answered retention question)

## Test plan
- [ ] Run `./scripts/check-links.py` — all links valid
- [ ] Verify rendered pages in docsify: user.md, current-limitations.md, open-questions.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)