### PR TITLE
Enable Docsify search plugin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,10 +16,16 @@
       repo: 'andreichenchik/robe-doc',
       loadSidebar: true,
       subMaxLevel: 2,
-      relativePath: true
+      relativePath: true,
+      search: {
+        placeholder: 'Search',
+        noData: 'No results',
+        depth: 3
+      }
     }
   </script>
   <!-- Docsify v4 -->
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add search plugin to Docsify configuration
- Configure placeholder text, empty results message, and heading depth

## Test plan
- [ ] Run `npx docsify-cli serve docs` locally
- [ ] Verify search box appears in sidebar
- [ ] Test search functionality finds content across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)