### PR TITLE
Fix post-merge review issues from PRs #67-#71

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -16,6 +16,9 @@ This repository contains product documentation for ROBE — a mobile application
 ## Documentation Structure
 
 ```
+.agent/
+├── AGENTS.md          # Agent instructions (source of truth)
+└── skills/            # Agent skills
 docs/
 ├── README.md          # Product vision and overview
 ├── _sidebar.md       # Docsify navigation (keep in sync with content)
@@ -85,7 +88,7 @@ Each logically distinct change should be submitted as a separate pull request. D
 Before committing, verify that all related parts of the documentation are consistent with the change:
 
 - `_sidebar.md` reflects any added, removed, or renamed pages.
-- `CLAUDE.md` documentation structure tree is up to date.
+- `.agent/AGENTS.md` documentation structure tree is up to date.
 - Cross-links in other files still point to valid targets — run `./scripts/check-links.py` to verify.
 - Existing docs that reference the changed concept are updated if needed.
 

--- a/docs/constraints/current-limitations.md
+++ b/docs/constraints/current-limitations.md
@@ -18,9 +18,9 @@ As limitations are resolved, remove them from this list.
 
 ---
 
-## No Default Collections
+## Default Starter Collections Not Yet Implemented
 
-[Collection](../domain/collection.md) states that no collections exist by default. While accurate today, the goal is to provide a set of predefined starter collections for new users so that the wardrobe is useful from the start.
+[Collection](../domain/collection.md) mentions predefined starter collections for new users. Currently, no collections exist by default — users must create all collections manually.
 
 ---
 
@@ -39,3 +39,9 @@ As limitations are resolved, remove them from this list.
 ## Account Deletion Does Not Clean Up Cloud Data
 
 [User](../domain/user.md) states that all associated data is removed when an account is deleted. Currently, cloud-stored files (item images and other uploads) are not cleaned up during deletion and remain as orphans.
+
+---
+
+## Outfit Photo Gallery Not Yet Implemented
+
+[Outfit](../domain/outfit.md) supports multiple photos per outfit. Currently, only a single photo can be attached to an outfit.

--- a/docs/domain/collection.md
+++ b/docs/domain/collection.md
@@ -2,7 +2,7 @@
 
 A user-created grouping for organizing [Items](./item.md) and [Outfits](./outfit.md) beyond the [Category](./category.md) hierarchy.
 
-Collections let users define their own cross-cutting labels (e.g. "sporty", "evening", "favorites", "to donate"). No collections exist by default — users create them as needed.
+Collections let users define their own cross-cutting labels (e.g. "sporty", "evening", "favorites", "to donate"). Users create collections as needed. The system may also provide predefined starter collections for new users — see [Current Limitations](../constraints/current-limitations.md).
 
 ## Properties
 

--- a/docs/domain/item.md
+++ b/docs/domain/item.md
@@ -13,7 +13,7 @@ A piece in the user's digital wardrobe. Item is the central entity of the system
 - **Favorite** — marks the item as a favorite.
 - **Collections** — user-defined groupings for organization. See [Collection](./collection.md).
 
-All attributes except Hidden and Favorite are auto-detected or suggested by [AI Classification](../features/ai-classification.md) on creation and can be edited by the user.
+Some attributes are auto-detected by [AI Classification](../features/ai-classification.md) on creation. All attributes can be edited by the user.
 
 > [!NOTE]
 > **Undefined — requires clarification:**

--- a/docs/domain/outfit.md
+++ b/docs/domain/outfit.md
@@ -7,7 +7,7 @@ A combination of [Items](./item.md) arranged together to represent a look. Users
 - **Name** — optional, empty by default. The user can set it manually. Unlike [Item](./item.md), there is nothing to auto-generate a name from.
 - **Collage data** — positions, scales, and rotations of items on the collage. Uses normalized coordinates for multi-screen support. See [Collage Data Model](#collage-data-model).
 - **Items** — the clothing pieces included in this outfit. An outfit must contain at least one item. See [Item](./item.md).
-- **Photo** — an optional user-taken photo of the outfit being worn (e.g. a mirror selfie). Currently a single photo, separate from the collage.
+- **Photos** — optional user-taken photos of the outfit being worn (e.g. mirror selfies). Separate from the collage. See [Current Limitations](../constraints/current-limitations.md) for implementation status.
 - **Draft** — when enabled, marks the outfit as a work in progress. Drafts appear in the outfit list alongside regular outfits by default. A filter allows showing only drafts.
 - **Favorite** — marks the outfit as a favorite.
 - **Collections** — user-defined groupings for organization. See [Collection](./collection.md).
@@ -16,8 +16,7 @@ A combination of [Items](./item.md) arranged together to represent a look. Users
 > **Undefined — requires clarification:**
 > - Is there an Outfit description or notes field?
 > - What metadata is stored (creation date, etc.)?
-> - Is the photo taken within the app or imported from the gallery?
-> - Could the photo property expand to a gallery (multiple photos per outfit) in the future?
+> - Are photos taken within the app or imported from the device gallery?
 
 ## Relationships
 

--- a/docs/features/outfit-collage.md
+++ b/docs/features/outfit-collage.md
@@ -19,7 +19,7 @@ Let users visually combine clothing pieces into a look by dragging and positioni
 - Items can be repositioned via drag-and-drop.
 - Items can be scaled using pinch-to-zoom and rotated.
 - Z-order is implicit — touching an item brings it to the top layer. The least recently touched item sits at the bottom. There is no explicit bring-to-front or send-to-back control.
-- The collage has a fixed aspect ratio, consistent across the app.
+- The collage has a fixed 3.7:5 aspect ratio, consistent across the app.
 - Only items are allowed on the collage — no images, text, stickers, or other decorative elements.
 - The collage must contain at least one item (an empty collage is not possible).
 - Collage state is persisted on save.
@@ -27,6 +27,7 @@ Let users visually combine clothing pieces into a look by dragging and positioni
 > [!NOTE]
 > **Undefined — requires clarification:**
 > - Could the collage support additional content types (text, stickers) in the future?
+> - The aspect ratio may change in future versions.
 
 ## Technical Details
 


### PR DESCRIPTION
## Summary

Fixes identified during post-merge reviews of PRs #67-#71:

- **item.md**: Simplify auto-detection text — removed specific attribute list
- **collection.md**: Document planned starter collections, link to limitations
- **current-limitations.md**: Update collections wording, add photo gallery limitation
- **outfit.md**: Change Photo → Photos (gallery support), update NOTE block
- **outfit-collage.md**: Specify 3.7:5 aspect ratio, note it may change
- **AGENTS.md**: Fix self-reference on line 88, add `.agent/` to structure diagram

## Test plan

- [x] `./scripts/check-links.py` — all links valid
- [ ] Preview with `npx docsify-cli serve docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)