### PR TITLE
Fix duplicate workflow runs on issue creation

### DIFF
--- a/.github/workflows/new-form-request.yml
+++ b/.github/workflows/new-form-request.yml
@@ -2,7 +2,11 @@ name: New Form Request
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened]
+
+concurrency:
+  group: refine-issue-${{ github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   refine:


### PR DESCRIPTION
## Summary

- Change trigger from `[opened, labeled]` to `[opened]` only — Zapier always creates issues with `feedbackForm` label attached, so the `labeled` event is redundant and causes a concurrent duplicate run
- Add `concurrency` group per issue number as safety net against race conditions

## Problem

When Zapier creates an issue with the `feedbackForm` label, GitHub fires both `opened` and `labeled` events simultaneously, causing two identical workflow runs that compete with each other. Additionally, when the workflow itself adds labels (`refined`, `bug`, etc.), each triggers another `labeled` event (filtered out by the `refined` check, but still noisy).

## Test plan

- [ ] Create a test issue with `feedbackForm` label — should trigger exactly one workflow run
- [ ] Verify the `refined` check still prevents reprocessing

🤖 Generated with [Claude Code](https://claude.com/claude-code)