### PR TITLE
Fix prioritization: add gh api to allowed tools, increase max_turns

### DIFF
--- a/.github/workflows/new-form-request.yml
+++ b/.github/workflows/new-form-request.yml
@@ -47,8 +47,9 @@ jobs:
         with:
           github_token: ${{ secrets.GH_PROJECT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          max_turns: 20
           claude_args: |
-            --allowedTools "Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh project item-list:*),Bash(gh project item-edit:*),Bash(gh project field-list:*),Bash(gh project view:*),Read"
+            --allowedTools "Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh project item-list:*),Bash(gh project item-edit:*),Bash(gh project field-list:*),Bash(gh project view:*),Bash(gh api:*),Read"
           prompt: |
             Read the file `.agent/prompts/prioritize-issue.md` for instructions.
 


### PR DESCRIPTION
## Summary

- Add `Bash(gh api:*)` to allowed tools — Claude sometimes uses `gh api graphql` instead of `gh project` CLI commands for project field lookups
- Set `max_turns: 20` to ensure all prioritization steps complete (the default was too low for field lookup + item lookup + edit + comment)

## Root cause

Issue #78 test: labels and comment were applied correctly, but project priority was not set. Claude used `gh api graphql` to look up the Priority field (which was not in the allowed tools), and likely ran out of turns before completing the project edit.

## Test plan

- [ ] Create a test issue and verify priority is set on the project board

🤖 Generated with [Claude Code](https://claude.com/claude-code)