### PR TITLE
Remove unsupported max_turns input from workflow

### DIFF
--- a/.github/workflows/new-form-request.yml
+++ b/.github/workflows/new-form-request.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           github_token: ${{ secrets.GH_PROJECT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          max_turns: 20
           claude_args: |
             --allowedTools "Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh project item-list:*),Bash(gh project item-edit:*),Bash(gh project field-list:*),Bash(gh project view:*),Bash(gh api:*),Read"
           prompt: |


### PR DESCRIPTION
## Summary
- Removes the `max_turns: 20` input from the Prioritize Issue step in `new-form-request.yml`
- This input is not supported by `claude-code-action` and produces an annotation warning on every run

## Test plan
- [ ] Verify workflow runs without the "Unexpected input 'max_turns'" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)