### PR TITLE
Switch Docsify theme to theme-simple

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Product documentation for ROBE — a smart digital wardrobe iOS app">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css">
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
## Summary
- Replace default vue theme with docsify-themeable `theme-simple` for a cleaner documentation appearance

## Test plan
- [ ] Run `npx docsify-cli serve docs` and verify the new theme renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)