### PR TITLE
Shorten documentation title to ROBE

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# ROBE Documentation
+# ROBE
 
 ROBE is a mobile application for digital wardrobe management. It helps users solve two everyday problems:
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,4 +1,4 @@
-- [ROBE Documentation](/)
+- [ROBE](/)
 
 - **Constraints**
   - [Platform](/constraints/platform.md)


### PR DESCRIPTION
## Summary
- Renamed heading in `docs/README.md` from "ROBE Documentation" to "ROBE"
- Updated sidebar link in `docs/_sidebar.md` to match

## Test plan
- [ ] Verify Docsify site renders the updated title
- [ ] Verify sidebar displays "ROBE" instead of "ROBE Documentation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)