### PR TITLE
Clarify sync scope, limitations, and resolve open questions

### DIFF
--- a/docs/constraints/data-sync.md
+++ b/docs/constraints/data-sync.md
@@ -14,11 +14,16 @@ User data is synchronized to a backend to support:
 - **Multi-device access** — signing in on a new device restores the full wardrobe.
 - **Data recovery** — reinstalling the app or switching devices does not result in data loss.
 
+Synchronized data includes:
+
+- [Items](../domain/item.md), including their properties and related image files.
+- [Outfits](../domain/outfit.md), including their properties and related image files.
+- [Collections](../domain/collection.md).
+
 The backend serves as a secondary copy. The local device is the source of truth during normal operation.
 
 > [!NOTE]
 > **Undefined — requires clarification:**
 > - Conflict resolution strategy when the same data is modified on multiple devices.
-> - What exactly is synced (items, outfits, collections, preferences, photos)?
 > - Whether sync happens in real-time, periodically, or on specific triggers.
 > - Behavior when sync fails or is interrupted.

--- a/docs/constraints/open-questions.md
+++ b/docs/constraints/open-questions.md
@@ -10,6 +10,8 @@ How users sign in and identify themselves. Affects onboarding complexity, accoun
 
 Apple Sign In is the only authentication method, and it is required — there is no guest or anonymous usage. Account deletion is immediate with no data retention. See [User](../domain/user.md) for details.
 
+Current limitation: account deletion does not yet fully remove cloud-stored files. See [Current Limitations](./current-limitations.md#account-deletion-does-not-clean-up-cloud-data).
+
 - What happens if a user loses access to their Apple ID — is there an account recovery path?
 
 See also: [Onboarding](../flows/onboarding.md).
@@ -20,7 +22,9 @@ See also: [Onboarding](../flows/onboarding.md).
 
 Whether the system imposes limits on user data. Affects product positioning and infrastructure costs.
 
-Item count is limited for free users and unlimited (or higher) for subscribers. See [User](../domain/user.md).
+Target behavior: item count is limited for free users and unlimited (or higher) for subscribers. See [User](../domain/user.md).
+
+Current limitation: subscription gating and item limits are not yet implemented. See [Current Limitations](./current-limitations.md#subscription-not-yet-implemented).
 
 - What is the specific item limit for free users?
 - Are there limits on outfits or collections?
@@ -40,7 +44,9 @@ How user data — especially photos — is handled. Affects trust, compliance, a
 
 ## Monetization
 
-The business model is freemium with a subscription that unlocks full functionality. See [User](../domain/user.md) for the subscription concept.
+Target business model: freemium with a subscription that unlocks full functionality. See [User](../domain/user.md) for the subscription concept.
+
+Current limitation: subscription gating and item limits are not yet implemented. See [Current Limitations](./current-limitations.md#subscription-not-yet-implemented).
 
 - Which specific features are gated behind the paywall?
 - Is there a trial period for the subscription?

--- a/docs/flows/create-outfit.md
+++ b/docs/flows/create-outfit.md
@@ -13,7 +13,7 @@ User initiates "create outfit" action.
 ## Steps
 
 1. **Select items** — User picks [Items](../domain/item.md) from their wardrobe to include in the outfit. At least one item is required.
-2. **Arrange on collage** — User arranges items on the [Outfit Collage](../features/outfit-collage.md) by dragging, scaling, and rotating them.
+2. **Arrange on collage** — User arranges items on the [Outfit Collage](../features/outfit-collage.md) by dragging, scaling, and rotating them. In the collage editor, items can also be added or removed.
 3. **Set outfit details** — User optionally sets a name, marks the outfit as a draft or favorite, and assigns [Collections](../domain/collection.md).
 4. **Save** — The [Outfit](../domain/outfit.md) is saved with its collage state.
 
@@ -23,7 +23,6 @@ A new Outfit is created and visible in the user's outfit list. The collage serve
 
 > [!NOTE]
 > **Undefined — requires clarification:**
-> - Can items be added or removed from the collage after the initial selection?
 > - Can the user share the outfit (export as image)?
 
 ## Error Scenarios

--- a/docs/flows/onboarding.md
+++ b/docs/flows/onboarding.md
@@ -11,6 +11,8 @@ User opens the app for the first time or after signing out.
 1. **Welcome screen** — A single page showing the app logo and main slogan.
 2. **Sign in** — [User](../domain/user.md) authenticates with their account.
 
+There is no "skip" or "explore without account" mode — authentication is required.
+
 ## Result
 
 The user is authenticated and enters the main app screen with access to their wardrobe.
@@ -20,7 +22,6 @@ The user is authenticated and enters the main app screen with access to their wa
 > - What is the main slogan text?
 > - Is there any additional content on the welcome screen (feature highlights, illustrations)?
 > - What happens if the user dismisses the Apple ID prompt — can they retry?
-> - Is there a "skip" or "explore without account" option?
 > - Where does the user land after sign-in — wardrobe tab, empty state, or a tutorial?
 > - Is there a different experience for returning users (sign-in only, no welcome screen)?
 


### PR DESCRIPTION
## Summary
- Specify what data is synced (items, outfits, collections) in data-sync constraints
- Add cross-links from open-questions to current-limitations for subscription and account deletion
- Clarify that collage editor allows adding/removing items mid-editing
- Confirm no guest/anonymous mode in onboarding
- Remove four resolved `> [!NOTE]` blocks

## Test plan
- [x] `check-links.py` passes — all links valid across 29 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)